### PR TITLE
Added a setting for forcing relative lines on or off no matter what the mode is.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,17 @@ VintageLines is available via [Sublime Package Control](http://wbond.net/sublime
 #### Normal lines in insert mode
 ![Normal line numbers in insert mode](https://raw.github.com/tmanderson/VintageLines/master/screenshots/screenshot2.png)
 
+### Notes
+
+If you prefer to always have relative line numbers on set the setting "vintage_lines.force_mode": true.
+
+If you prefer a key binding toggle relative lines on and off you can set one up by using key binding code like the following:
+
+        {"keys": ["ctrl+t"], "command": "toggle_setting", "args": {"setting": "vintage_lines.force_mode"}}
+
+Note that you should also set vintage_lines.force_mode in your User Preferences to your preferred default
+for the toggle to be effective in both command mode and insert mode.
+
 ### CONTRIBUTORS (THANKS A LOT!):
 - [@kuroir](https://github.com/kuroir)
 - [@quarnster](https://github.com/quarnster)

--- a/vintageLines.py
+++ b/vintageLines.py
@@ -40,7 +40,10 @@ class VintageLinesEventListener(sublime_plugin.EventListener):
 		if self.view:
 			settings = self.view.settings()
 
-			show = settings.get('command_mode')
+			if settings.has("vintage_lines.force_mode"):
+				show = settings.get("vintage_lines.force_mode")
+			else:
+				show = settings.get('command_mode')
 			mode = settings.get('vintage_lines.mode', False)
 			line = settings.get('vintage_lines.line', -1)
 			lines = settings.get('vintage_lines.lines', -1)


### PR DESCRIPTION
Related to issue #12 and #13 added a setting for forcing relative
lines on or off no matter what the mode is. This can be used
together with a keybinding to toggle relative line modes on and off
